### PR TITLE
v0.4.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,6 +1,6 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-name: Java + Maven CI
+name: Build & Test
 
 on:
   push:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,8 @@ on:
     branches: [ master, development ]
   pull_request:
     branches: [ master, development ]
+  schedule:
+    - cron: "0 0 * * *" # At the end of every day
 
 env:
   PLUGGY_CLIENT_ID: "ccd5b9be-3be6-45fe-9512-5907f1619db0"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently, the package is available in Github Packages, so make sure to have the
 <dependency>
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>0.3.1</version>
+  <version>0.3.2-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Currently, the package is available in Github Packages, so make sure to have the
 <dependency>
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>0.3.2-SNAPSHOT</version>
+  <version>0.4.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pluggy Java
 
+[![Actions Status](https://github.com/pluggyai/pluggy-java/workflows/Build%20%26%20Test/badge.svg)](https://github.com/pluggyai/pluggy-java/actions?query=workflow%3A"Build+%26+Test")
+
 Java Bindings for the Pluggy API (https://docs.pluggy.ai/).
 
 For available SDK API methods, check [PluggyApiService](./src/main/java/ai/pluggy/client/PluggyApiService.java) interface methods.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>0.3.2-SNAPSHOT</version>
+  <version>0.4.0</version>
 
   <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>0.3.1</version>
+  <version>0.3.2-SNAPSHOT</version>
 
   <packaging>jar</packaging>
 

--- a/src/main/java/ai/pluggy/client/PluggyApiService.java
+++ b/src/main/java/ai/pluggy/client/PluggyApiService.java
@@ -12,6 +12,7 @@ import ai.pluggy.client.response.Category;
 import ai.pluggy.client.response.Connector;
 import ai.pluggy.client.response.ConnectorsResponse;
 import ai.pluggy.client.response.DeleteItemResponse;
+import ai.pluggy.client.response.IdentityResponse;
 import ai.pluggy.client.response.Investment;
 import ai.pluggy.client.response.InvestmentsResponse;
 import ai.pluggy.client.response.ItemResponse;
@@ -36,6 +37,12 @@ public interface PluggyApiService {
 
   @GET("/connectors/{id}")
   Call<Connector> getConnector(@Path("id") Integer connectorId);
+
+  @GET("/identity")
+  Call<IdentityResponse> getIdentityByItemId(@Query("itemId") String itemId);
+
+  @GET("/identity/{id}")
+  Call<IdentityResponse> getIdentityById(@Path("id") String identityId);
 
   @POST("/items")
   Call<ItemResponse> createItem(@Body CreateItemRequest createItemRequest);

--- a/src/main/java/ai/pluggy/client/PluggyApiService.java
+++ b/src/main/java/ai/pluggy/client/PluggyApiService.java
@@ -41,8 +41,11 @@ public interface PluggyApiService {
   Call<ItemResponse> createItem(@Body CreateItemRequest createItemRequest);
 
   @PATCH("/items/{id}")
+  Call<ItemResponse> updateItem(@Path("id") String itemId);
+
+  @PATCH("/items/{id}")
   Call<ItemResponse> updateItem(@Path("id") String itemId,
-    @Body UpdateItemRequest createItemRequest);
+    @Body UpdateItemRequest updateItemRequest);
 
   @GET("/items/{id}")
   Call<ItemResponse> getItem(@Path("id") String itemId);

--- a/src/main/java/ai/pluggy/client/request/ConnectorsSearchRequest.java
+++ b/src/main/java/ai/pluggy/client/request/ConnectorsSearchRequest.java
@@ -1,5 +1,6 @@
 package ai.pluggy.client.request;
 
+import ai.pluggy.utils.Asserts;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -30,4 +31,33 @@ public class ConnectorsSearchRequest extends HashMap<String, String> {
     }
   }
 
+  public ConnectorsSearchRequest setName(String name) {
+    Asserts.assertNotNull(name, "name");
+    put("name", name);
+    return this;
+  }
+
+  public ConnectorsSearchRequest setCountries(List<String> countries) {
+    String field = "countries";
+    Asserts.assertNotNull(countries, field);
+    put(field, String.join(",", countries));
+    return this;
+  }
+
+  public ConnectorsSearchRequest setTypes(List<String> types) {
+    String field = "types";
+    Asserts.assertNotNull(types, field);
+    put(field, String.join(",", types));
+    return this;
+  }
+
+  /**
+   * @param includeSandbox If set to true, the response will include sandbox connectors. Otherwise, they won't be included.
+   */
+  public ConnectorsSearchRequest setIncludeSandbox(Boolean includeSandbox) {
+    String field = "sandbox";
+    Asserts.assertNotNull(includeSandbox, field);
+    put(field, String.valueOf(includeSandbox));
+    return this;
+  }
 }

--- a/src/main/java/ai/pluggy/client/request/UpdateItemRequest.java
+++ b/src/main/java/ai/pluggy/client/request/UpdateItemRequest.java
@@ -3,10 +3,12 @@ package ai.pluggy.client.request;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class UpdateItemRequest {
   Integer connectorId;
   ParametersMap parameters;

--- a/src/main/java/ai/pluggy/client/response/Address.java
+++ b/src/main/java/ai/pluggy/client/response/Address.java
@@ -1,0 +1,17 @@
+package ai.pluggy.client.response;
+
+import lombok.Data;
+
+@Data
+public class Address {
+
+  String fullAddress;
+  String country;
+  String state;
+  String city;
+  String postalCode;
+  String primaryAddress;
+
+  // "Personal", "Work"
+  String type;
+}

--- a/src/main/java/ai/pluggy/client/response/Email.java
+++ b/src/main/java/ai/pluggy/client/response/Email.java
@@ -1,0 +1,11 @@
+package ai.pluggy.client.response;
+
+import lombok.Data;
+
+@Data
+public class Email {
+
+  // "Personal", "Work"
+  String type;
+  String value;
+}

--- a/src/main/java/ai/pluggy/client/response/IdentityRelation.java
+++ b/src/main/java/ai/pluggy/client/response/IdentityRelation.java
@@ -1,0 +1,12 @@
+package ai.pluggy.client.response;
+
+import lombok.Data;
+
+@Data
+public class IdentityRelation {
+
+  // 'Mother' | 'Father' | 'Spouse'
+  String type;
+  String name;
+  String document;
+}

--- a/src/main/java/ai/pluggy/client/response/IdentityResponse.java
+++ b/src/main/java/ai/pluggy/client/response/IdentityResponse.java
@@ -1,0 +1,26 @@
+package ai.pluggy.client.response;
+
+import java.util.Date;
+import java.util.List;
+import lombok.Data;
+
+/**
+ * GET /identity
+ */
+@Data
+public class IdentityResponse {
+
+  String id;
+  String fullName;
+  String document;
+  String taxNumber;
+  String documentType;
+  String jobTitle;
+  Date birthDate;
+  List<Address> addresses;
+  List<PhoneNumber> phoneNumbers;
+  List<Email> emails;
+  List<IdentityRelation> identityRelations;
+  Date createdAt;
+  Date updatedAt;
+}

--- a/src/main/java/ai/pluggy/client/response/ItemResponse.java
+++ b/src/main/java/ai/pluggy/client/response/ItemResponse.java
@@ -8,9 +8,7 @@ public class ItemResponse {
 
   String id;
   String user;
-  Integer userId;
   Connector connector;
-  Integer connectorId;
   Date createdAt;
   Date updatedAt;
   String status;

--- a/src/main/java/ai/pluggy/client/response/PhoneNumber.java
+++ b/src/main/java/ai/pluggy/client/response/PhoneNumber.java
@@ -1,0 +1,11 @@
+package ai.pluggy.client.response;
+
+import lombok.Data;
+
+@Data
+public class PhoneNumber {
+
+  // "Personal", "Work", "Residencial"
+  String type;
+  String value;
+}

--- a/src/test/java/ai/pluggy/client/integration/BaseApiIntegrationTest.java
+++ b/src/test/java/ai/pluggy/client/integration/BaseApiIntegrationTest.java
@@ -10,7 +10,7 @@ import org.junit.platform.commons.util.StringUtils;
 class BaseApiIntegrationTest {
 
   static final String CLIENT_ID = System.getenv("PLUGGY_CLIENT_ID");
-  private static final String CLIENT_SECRET = System.getenv("PLUGGY_CLIENT_SECRET");
+  static final String CLIENT_SECRET = System.getenv("PLUGGY_CLIENT_SECRET");
   static final String TEST_BASE_URL = System.getenv("PLUGGY_BASE_URL");
 
   PluggyClient client;
@@ -24,7 +24,7 @@ class BaseApiIntegrationTest {
       .build();
   }
 
-  private void checkEnvErrors() {
+  protected void checkEnvErrors() {
     List<String> missingEnvVars = new ArrayList<>();
     if (StringUtils.isBlank(CLIENT_ID)) {
       missingEnvVars.add("PLUGGY_CLIENT_ID");

--- a/src/test/java/ai/pluggy/client/integration/CreateItemTest.java
+++ b/src/test/java/ai/pluggy/client/integration/CreateItemTest.java
@@ -22,7 +22,7 @@ public class CreateItemTest extends BaseApiIntegrationTest {
     // create item params
     ParametersMap parametersMap = ParametersMap.map("user", "asd")
       .with("password", "qwe")
-      .with("cuit", "20-34232323-2");
+      .with("dni", "123123123");
     Integer connectorId = 101;
 
     // run request with 'connectorId', 'parameters' params
@@ -34,7 +34,7 @@ public class CreateItemTest extends BaseApiIntegrationTest {
     ItemResponse itemResponse1 = itemRequestResponse.body();
 
     assertNotNull(itemResponse1);
-    assertEquals(itemResponse1.getConnectorId(), connectorId);
+    assertEquals(itemResponse1.getConnector().getId(), connectorId);
 
     // run request with 'connectorId', 'parameters', 'webhookUrl' params
     String webhookUrl = "https://www.test.com/";
@@ -45,7 +45,7 @@ public class CreateItemTest extends BaseApiIntegrationTest {
     ItemResponse itemResponse2 = itemRequestWithWebhookResponse.body();
 
     assertNotNull(itemResponse2);
-    assertEquals(itemResponse2.getConnectorId(), connectorId);
+    assertEquals(itemResponse2.getConnector().getId(), connectorId);
   }
 
   @SneakyThrows

--- a/src/test/java/ai/pluggy/client/integration/CreateItemTest.java
+++ b/src/test/java/ai/pluggy/client/integration/CreateItemTest.java
@@ -23,7 +23,7 @@ public class CreateItemTest extends BaseApiIntegrationTest {
     ParametersMap parametersMap = ParametersMap.map("user", "asd")
       .with("password", "qwe")
       .with("cuit", "20-34232323-2");
-    Integer connectorId = 1;
+    Integer connectorId = 101;
 
     // run request with 'connectorId', 'parameters' params
     CreateItemRequest createItemRequest = new CreateItemRequest(connectorId, parametersMap);

--- a/src/test/java/ai/pluggy/client/integration/DeleteItemTest.java
+++ b/src/test/java/ai/pluggy/client/integration/DeleteItemTest.java
@@ -18,7 +18,7 @@ public class DeleteItemTest extends BaseApiIntegrationTest {
   @Test
   void deleteItem_existingItemId_ok() throws IOException {
     // ensure item exists
-    Integer connectorId = 1;
+    Integer connectorId = 101;
     ItemResponse item = createItem(client, connectorId);
     assertNotNull(item);
 

--- a/src/test/java/ai/pluggy/client/integration/GetConnectorTest.java
+++ b/src/test/java/ai/pluggy/client/integration/GetConnectorTest.java
@@ -13,7 +13,7 @@ class GetConnectorTest extends BaseApiIntegrationTest {
 
   @Test
   void getConnector_byExistingId_returnsOneResult() throws IOException {
-    Integer existingConnectorId = 1;
+    Integer existingconnectorId = 101;
     Response<Connector> response = client.service().getConnector(existingConnectorId).execute();
     Connector existingConnector = response.body();
     assertNotNull(existingConnector);

--- a/src/test/java/ai/pluggy/client/integration/GetConnectorTest.java
+++ b/src/test/java/ai/pluggy/client/integration/GetConnectorTest.java
@@ -13,7 +13,7 @@ class GetConnectorTest extends BaseApiIntegrationTest {
 
   @Test
   void getConnector_byExistingId_returnsOneResult() throws IOException {
-    Integer existingconnectorId = 101;
+    Integer existingConnectorId = 101;
     Response<Connector> response = client.service().getConnector(existingConnectorId).execute();
     Connector existingConnector = response.body();
     assertNotNull(existingConnector);

--- a/src/test/java/ai/pluggy/client/integration/GetConnectorsTest.java
+++ b/src/test/java/ai/pluggy/client/integration/GetConnectorsTest.java
@@ -30,6 +30,8 @@ class GetConnectorsTest extends BaseApiIntegrationTest {
     // request connectors with filters
     ConnectorsResponse connectorsFilteredByName = client.service()
       .getConnectors(new ConnectorsSearchRequest("BBVA")).execute().body();
+    ConnectorsResponse connectorsFilteredIncludeSandbox = client.service()
+      .getConnectors(new ConnectorsSearchRequest().setIncludeSandbox(true)).execute().body();
     ConnectorsResponse connectorsFilteredByOneCountry = client.service()
       .getConnectors(new ConnectorsSearchRequest(null, Collections.singletonList("AR"))).execute()
       .body();
@@ -40,6 +42,7 @@ class GetConnectorsTest extends BaseApiIntegrationTest {
         Collections.singletonList("BUSINESS_BANK"))).execute().body();
 
     int allCount = defaultConnectors.getResults().size();
+    int allIncludeSandboxCount = connectorsFilteredIncludeSandbox.getResults().size();
     int byNameCount = connectorsFilteredByName.getResults().size();
     int byOneCountryCount = connectorsFilteredByOneCountry.getResults().size();
     int byTwoCountriesCount = connectorsFilteredByTwoCountries.getResults().size();
@@ -47,16 +50,20 @@ class GetConnectorsTest extends BaseApiIntegrationTest {
 
     // assumes that API has data results for all filtered requests
     assertTrue(allCount > 0);
+    assertTrue(allIncludeSandboxCount > 0);
     assertTrue(byNameCount > 0);
     assertTrue(byOneCountryCount > 0);
     assertTrue(byTwoCountriesCount > 0);
     assertTrue(byOneCountryAndOneTypeCount > 0);
 
-    // assumes filtered results are less than total result
+    // assumes filtered results are less than default total result
     assertTrue(byNameCount < allCount);
     assertTrue(byOneCountryCount < allCount);
     assertTrue(byTwoCountriesCount <= allCount);
     assertTrue(byOneCountryAndOneTypeCount < allCount);
+
+    // assumes including sandbox results are more than default total result
+    assertTrue(allIncludeSandboxCount > allCount);
 
     // assumes filtering by one country results are less than by two countries
     assertTrue(byOneCountryCount < byTwoCountriesCount);

--- a/src/test/java/ai/pluggy/client/integration/GetConnectorsTest.java
+++ b/src/test/java/ai/pluggy/client/integration/GetConnectorsTest.java
@@ -24,12 +24,12 @@ class GetConnectorsTest extends BaseApiIntegrationTest {
   @Test
   void getConnectors_withParams_returnsFilteredResults() throws IOException {
     // request connectors with empty filters
-    ConnectorsResponse allConnectors = client.service()
+    ConnectorsResponse defaultConnectors = client.service()
       .getConnectors(new ConnectorsSearchRequest()).execute().body();
 
     // request connectors with filters
     ConnectorsResponse connectorsFilteredByName = client.service()
-      .getConnectors(new ConnectorsSearchRequest("Pluggy")).execute().body();
+      .getConnectors(new ConnectorsSearchRequest("BBVA")).execute().body();
     ConnectorsResponse connectorsFilteredByOneCountry = client.service()
       .getConnectors(new ConnectorsSearchRequest(null, Collections.singletonList("AR"))).execute()
       .body();
@@ -39,7 +39,7 @@ class GetConnectorsTest extends BaseApiIntegrationTest {
       .getConnectors(new ConnectorsSearchRequest(null, Collections.singletonList("AR"),
         Collections.singletonList("BUSINESS_BANK"))).execute().body();
 
-    int allCount = allConnectors.getResults().size();
+    int allCount = defaultConnectors.getResults().size();
     int byNameCount = connectorsFilteredByName.getResults().size();
     int byOneCountryCount = connectorsFilteredByOneCountry.getResults().size();
     int byTwoCountriesCount = connectorsFilteredByTwoCountries.getResults().size();

--- a/src/test/java/ai/pluggy/client/integration/GetIdentityTest.java
+++ b/src/test/java/ai/pluggy/client/integration/GetIdentityTest.java
@@ -1,0 +1,116 @@
+package ai.pluggy.client.integration;
+
+import static ai.pluggy.client.integration.helper.ItemHelper.createItem;
+import static ai.pluggy.client.integration.helper.ItemHelper.getItemStatus;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import ai.pluggy.client.integration.util.Poller;
+import ai.pluggy.client.request.ParametersMap;
+import ai.pluggy.client.response.ErrorResponse;
+import ai.pluggy.client.response.IdentityResponse;
+import ai.pluggy.client.response.ItemResponse;
+import java.util.Objects;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import retrofit2.Response;
+
+public class GetIdentityTest extends BaseApiIntegrationTest {
+
+  @SneakyThrows
+  @Test
+  void getIdentityByItemId_existingItemId_waitUntilCompleted_ok() {
+    // ensure item exists
+    Integer connectorId = 0;
+    ParametersMap validCredentials = ParametersMap.map("user", "user-ok")
+      .with("password", "password-ok");
+    ItemResponse item = createItem(client, connectorId, validCredentials);
+    assertNotNull(item);
+
+    String existingItemId = item.getId();
+
+    // wait until item completed (item status: "UPDATED")
+    Poller.pollRequestUntil(
+      () -> getItemStatus(client, item.getId()),
+      (ItemResponse itemResponse) -> Objects.equals(itemResponse.getStatus(), "UPDATED"),
+      500, 30000
+    );
+
+    // get identity by item id
+    Response<IdentityResponse> identityByItemIdResponse = client.service()
+      .getIdentityByItemId(existingItemId)
+      .execute();
+
+    // expect response to be OK (and not null)
+    assertEquals(200, identityByItemIdResponse.code());
+
+    IdentityResponse identityResponse = identityByItemIdResponse.body();
+    assertNotNull(identityResponse);
+  }
+
+  @SneakyThrows
+  @Test
+  void getIdentityByItemId_existingItemId_beforeCompleted_fails() {
+    // ensure item exists
+    Integer connectorId = 0;
+    ParametersMap validCredentials = ParametersMap.map("user", "user-ok")
+      .with("password", "password-ok");
+    ItemResponse item = createItem(client, connectorId, validCredentials);
+    assertNotNull(item);
+
+    String existingItemId = item.getId();
+
+    // get identity by item id
+    Response<IdentityResponse> identityByItemIdResponse = client.service()
+      .getIdentityByItemId(existingItemId)
+      .execute();
+
+    // expect response to be 404 not found
+    assertEquals(404, identityByItemIdResponse.code());
+
+    ErrorResponse errorResponse = client.parseError(identityByItemIdResponse);
+    assertEquals(404, errorResponse.getCode());
+  }
+
+
+  @SneakyThrows
+  @Test
+  void getIdentityById_existingIdentityOfExistingCompletedItemId_ok() {
+    // ensure item exists
+    Integer connectorId = 0;
+    ParametersMap validCredentials = ParametersMap.map("user", "user-ok")
+      .with("password", "password-ok");
+    ItemResponse item = createItem(client, connectorId, validCredentials);
+    assertNotNull(item);
+
+    String existingItemId = item.getId();
+
+    // wait until item completed (item status: "UPDATED")
+    Poller.pollRequestUntil(
+      () -> getItemStatus(client, existingItemId),
+      (ItemResponse itemResponse) -> Objects.equals(itemResponse.getStatus(), "UPDATED"),
+      500, 30000
+    );
+
+    // ensure identity by item id exists
+    Response<IdentityResponse> identityByItemIdResponse = client.service()
+      .getIdentityByItemId(existingItemId)
+      .execute();
+
+    IdentityResponse identityResponse = identityByItemIdResponse.body();
+    String identityId = identityResponse.getId();
+    assertNotNull(identityId);
+
+    // get identity by id
+    Response<IdentityResponse> identityByIdResponse = client.service().getIdentityById(identityId)
+      .execute();
+
+    // expect response to be OK and to match originally requested identity
+    assertEquals(identityByIdResponse.code(), 200);
+    IdentityResponse identityById = identityByIdResponse.body();
+    assertNotNull(identityById);
+    assertEquals(identityById.getId(), identityId);
+    assertEquals(identityById.getFullName(), identityResponse.getFullName());
+  }
+
+}

--- a/src/test/java/ai/pluggy/client/integration/GetItemTest.java
+++ b/src/test/java/ai/pluggy/client/integration/GetItemTest.java
@@ -22,7 +22,7 @@ public class GetItemTest extends BaseApiIntegrationTest {
   @Test
   void getItem_existingItem_ok() throws IOException {
     // ensure item exists
-    Integer connectorId = 1;
+    Integer connectorId = 101;
     ItemResponse item = createItem(client, connectorId);
     assertNotNull(item);
 

--- a/src/test/java/ai/pluggy/client/integration/GetTransactionsTest.java
+++ b/src/test/java/ai/pluggy/client/integration/GetTransactionsTest.java
@@ -45,7 +45,7 @@ public class GetTransactionsTest extends BaseApiIntegrationTest {
 
     // precondition: get account transactions (all results)
     Response<TransactionsResponse> allTransactionsResponse = client.service()
-      .getTransactions(firstAccountId)
+      .getTransactions(firstAccountId, new TransactionsSearchRequest().pageSize(100))
       .execute();
 
     TransactionsResponse allTransactionsResults = allTransactionsResponse.body();
@@ -79,11 +79,12 @@ public class GetTransactionsTest extends BaseApiIntegrationTest {
         minDate, middleDate));
 
     // get account transactions with sub-range date filters
-    String fromDateFilter = minDate.substring(0, 10);
+    String fromDateFilter = "2019-11-15";
     String toDateFilter = middleDate.substring(0, 10);
     TransactionsSearchRequest dateFilters = new TransactionsSearchRequest()
       .from(fromDateFilter)
-      .to(toDateFilter);
+      .to(toDateFilter)
+      .pageSize(100);
 
     Response<TransactionsResponse> transactionsFilteredResponse = client.service()
       .getTransactions(firstAccountId, dateFilters)

--- a/src/test/java/ai/pluggy/client/integration/UpdateItemTest.java
+++ b/src/test/java/ai/pluggy/client/integration/UpdateItemTest.java
@@ -25,11 +25,9 @@ public class UpdateItemTest extends BaseApiIntegrationTest {
   @Test
   void updateItem_beforeExecutionEnds_errorResponse() {
     // precondition: an item already exists
-    Integer connectorId = 1;
     ItemResponse itemResponse = createPluggyBankItem(client);
 
     // build update item request
-    ParametersMap newParameters = ParametersMap.map("user", "qwe");
     String newWebhookUrl = "https://www.test.com";
     UpdateItemRequest updateItemRequest = UpdateItemRequest.builder()
       .webhookUrl(newWebhookUrl)

--- a/src/test/java/ai/pluggy/client/integration/helper/ItemHelper.java
+++ b/src/test/java/ai/pluggy/client/integration/helper/ItemHelper.java
@@ -31,6 +31,7 @@ public class ItemHelper {
   public static ItemResponse createItem(PluggyClient client, Integer connectorId) {
     ParametersMap invalidParametersMap = ParametersMap.map("user", "asd")
       .with("password", "qwe")
+      .with("dni", "123123123")
       .with("cuit", "20-34232323-2");
 
     return createItem(client, connectorId, invalidParametersMap);


### PR DESCRIPTION
* Implement `updateItem(id)` overload method with no params, used to simply refresh an existing connector's active item.
* Fix `ItemResponse` fields to match recent API changes.
* Add support for 'sandbox' flag in `ConnectorsSearchRequest` query params, used to include sandbox connectors aditionally to the normal ones.
* Config: setup CI to run daily, at end of day. 
* Map & Implement `GET /identity` new API endpoint.