### PR TITLE
Feat/connector type connect token

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Currently, the package is available in Github Packages, so make sure to have the
 <dependency>
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>0.5.0</version>
+  <version>0.5.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>0.5.0</version>
+  <version>0.5.1</version>
 
   <packaging>jar</packaging>
 

--- a/src/main/java/ai/pluggy/client/PluggyApiService.java
+++ b/src/main/java/ai/pluggy/client/PluggyApiService.java
@@ -10,6 +10,7 @@ import ai.pluggy.client.response.Account;
 import ai.pluggy.client.response.AccountsResponse;
 import ai.pluggy.client.response.CategoriesResponse;
 import ai.pluggy.client.response.Category;
+import ai.pluggy.client.response.ConnectTokenResponse;
 import ai.pluggy.client.response.Connector;
 import ai.pluggy.client.response.ConnectorsResponse;
 import ai.pluggy.client.response.DeleteItemResponse;
@@ -97,4 +98,6 @@ public interface PluggyApiService {
   @GET("/categories/{id}")
   Call<Category> getCategory(@Path("id") String categoryId);
 
+  @POST("/connecttokens")
+  Call<ConnectTokenResponse> createConnectToken();
 }

--- a/src/main/java/ai/pluggy/client/request/ConnectorsSearchRequest.java
+++ b/src/main/java/ai/pluggy/client/request/ConnectorsSearchRequest.java
@@ -1,9 +1,11 @@
 package ai.pluggy.client.request;
 
+import ai.pluggy.client.response.ConnectorType;
 import ai.pluggy.utils.Asserts;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ConnectorsSearchRequest extends HashMap<String, String> {
 
@@ -19,7 +21,7 @@ public class ConnectorsSearchRequest extends HashMap<String, String> {
     this(name, countries, Collections.emptyList());
   }
 
-  public ConnectorsSearchRequest(String name, List<String> countries, List<String> types) {
+  public ConnectorsSearchRequest(String name, List<String> countries, List<ConnectorType> types) {
     if (name != null) {
       put("name", name);
     }
@@ -27,7 +29,8 @@ public class ConnectorsSearchRequest extends HashMap<String, String> {
       put("countries", String.join(",", countries));
     }
     if (types != null && types.size() > 0) {
-      put("types", String.join(",", types));
+      List<String> typesAsString = types.stream().map(Enum::toString).collect(Collectors.toList());
+      put("types", String.join(",", typesAsString));
     }
   }
 
@@ -44,10 +47,11 @@ public class ConnectorsSearchRequest extends HashMap<String, String> {
     return this;
   }
 
-  public ConnectorsSearchRequest setTypes(List<String> types) {
+  public ConnectorsSearchRequest setTypes(List<ConnectorType> types) {
     String field = "types";
     Asserts.assertNotNull(types, field);
-    put(field, String.join(",", types));
+    List<String> typesAsString = types.stream().map(Enum::toString).collect(Collectors.toList());
+    put(field, String.join(",", typesAsString));
     return this;
   }
 

--- a/src/main/java/ai/pluggy/client/response/ConnectTokenResponse.java
+++ b/src/main/java/ai/pluggy/client/response/ConnectTokenResponse.java
@@ -1,0 +1,9 @@
+package ai.pluggy.client.response;
+
+import lombok.Data;
+
+@Data
+public class ConnectTokenResponse {
+
+  String accessToken;
+}

--- a/src/main/java/ai/pluggy/client/response/Connector.java
+++ b/src/main/java/ai/pluggy/client/response/Connector.java
@@ -11,7 +11,7 @@ public class Connector {
   String primaryColor;
   String institutionUrl;
   String country;
-  String type;
+  ConnectorType type;
   List<CredentialLabel> credentials;
   String imageUrl;
   Boolean hasMFA;

--- a/src/main/java/ai/pluggy/client/response/ConnectorType.java
+++ b/src/main/java/ai/pluggy/client/response/ConnectorType.java
@@ -1,0 +1,18 @@
+package ai.pluggy.client.response;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public enum ConnectorType {
+  @SerializedName("INVESTMENT")
+  INVESTMENT("INVESTMENT"),
+  @SerializedName("BUSINESS_BANK")
+  BUSINESS_BANK("BUSINESS_BANK"),
+  @SerializedName("PERSONAL_BANK")
+  PERSONAL_BANK("PERSONAL_BANK");
+
+  @Getter
+  private String value;
+}

--- a/src/test/java/ai/pluggy/client/integration/CreateConnectTokenTest.java
+++ b/src/test/java/ai/pluggy/client/integration/CreateConnectTokenTest.java
@@ -1,0 +1,27 @@
+package ai.pluggy.client.integration;
+
+import static ai.pluggy.client.integration.util.AssertionsUtils.assertSuccessful;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.pluggy.client.response.ConnectTokenResponse;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.StringUtils;
+import retrofit2.Call;
+import retrofit2.Response;
+
+public class CreateConnectTokenTest extends BaseApiIntegrationTest {
+
+  @Test
+  void createConnectToken_ok() throws IOException {
+
+    Call<ConnectTokenResponse> createConnectTokenCall = client.service().createConnectToken();
+    Response<ConnectTokenResponse> connectTokenResponse = createConnectTokenCall.execute();
+    assertSuccessful(connectTokenResponse, client);
+    ConnectTokenResponse connectTokenResponseBody = connectTokenResponse.body();
+    assertNotNull(connectTokenResponseBody, "connectTokenResponse body should not be null");
+    assertTrue(StringUtils.isNotBlank(connectTokenResponseBody.getAccessToken()),
+      "connectTokenResponse.accessToken should not be null or empty");
+  }
+}

--- a/src/test/java/ai/pluggy/client/integration/GetConnectorsTest.java
+++ b/src/test/java/ai/pluggy/client/integration/GetConnectorsTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.pluggy.client.request.ConnectorsSearchRequest;
+import ai.pluggy.client.response.ConnectorType;
 import ai.pluggy.client.response.ConnectorsResponse;
 import java.io.IOException;
 import java.util.Arrays;
@@ -39,7 +40,7 @@ class GetConnectorsTest extends BaseApiIntegrationTest {
       .getConnectors(new ConnectorsSearchRequest(null, Arrays.asList("BR", "AR"))).execute().body();
     ConnectorsResponse connectorsFilteredByOneCountryAndOneType = client.service()
       .getConnectors(new ConnectorsSearchRequest(null, Collections.singletonList("AR"),
-        Collections.singletonList("BUSINESS_BANK"))).execute().body();
+        Collections.singletonList(ConnectorType.BUSINESS_BANK))).execute().body();
 
     int allCount = defaultConnectors.getResults().size();
     int allIncludeSandboxCount = connectorsFilteredIncludeSandbox.getResults().size();


### PR DESCRIPTION
* Map `ConnectorType` values
* Update ConnectorsSearchRequest API to use the new `ConnectorType type` param. Note that this would be a **breaking change** (previously String field type is now ConnectorType)
* Implement createConnectTokens() API method that maps `POST /connecttokens` request."

Tickets

https://pluggy.atlassian.net/browse/DVT-31
https://pluggy.atlassian.net/browse/DVT-76