### PR TITLE
fix(parseError): properly handle invalid JSON responses as API errors & parse them as an ErrorResponse in parseError().

### DIFF
--- a/src/main/java/ai/pluggy/client/PluggyClient.java
+++ b/src/main/java/ai/pluggy/client/PluggyClient.java
@@ -291,8 +291,7 @@ public final class PluggyClient {
         throw e;
       } catch (Exception e) {
         // non-successful or malformed JSON response
-        String pluggyResponseErrorMessage = buildResponseErrorMessage(
-          response);
+        String pluggyResponseErrorMessage = buildResponseErrorMessage(response);
 
         throw new PluggyException(pluggyResponseErrorMessage, response, e);
       }

--- a/src/main/java/ai/pluggy/client/PluggyClient.java
+++ b/src/main/java/ai/pluggy/client/PluggyClient.java
@@ -4,13 +4,14 @@ import static ai.pluggy.utils.Asserts.assertNotNull;
 import static ai.pluggy.utils.Asserts.assertValidUrl;
 
 import ai.pluggy.client.auth.ApiKeyAuthInterceptor;
-import ai.pluggy.client.response.AuthResponse;
+import ai.pluggy.client.auth.AuthenticationHelper;
 import ai.pluggy.client.response.ErrorResponse;
 import ai.pluggy.exception.PluggyException;
 import ai.pluggy.utils.Utils;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -20,12 +21,15 @@ import okhttp3.OkHttpClient;
 import okhttp3.OkHttpClient.Builder;
 import okhttp3.Request;
 import okhttp3.RequestBody;
+import okhttp3.Response;
 import okhttp3.ResponseBody;
+import org.jetbrains.annotations.NotNull;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 public final class PluggyClient {
 
+  public static final int ONE_MIB_BYTES = 1024 * 1024;
   public static String AUTH_URL_PATH = "/auth";
   private String baseUrl;
 
@@ -43,6 +47,36 @@ public final class PluggyClient {
 
   public static PluggyClientBuilder builder() {
     return new PluggyClientBuilder();
+  }
+
+  @NotNull
+  private static String buildResponseErrorMessage(Response response) {
+    String responseBodyString = null;
+    if (response.body() != null) {
+      try {
+        responseBodyString = response.peekBody(ONE_MIB_BYTES).string();
+      } catch (IOException e) {
+        // ignore, just leave responseBodyString as null
+      }
+    }
+
+    return buildResponseErrorMessage(response, responseBodyString);
+  }
+
+  private static String buildResponseErrorMessage(Response response, String responseBodyString) {
+    Request originalRequest = response.request();
+
+    String errorMessage = String.format("Pluggy '%s %s' request failed, message: %s (%d)",
+      originalRequest.method(),
+      originalRequest.url().encodedPath(),
+      response.message(),
+      response.code()
+    );
+
+    if (responseBodyString != null) {
+      errorMessage += " - response: '" + responseBodyString + "'";
+    }
+    return errorMessage;
   }
 
   public void setClientId(String clientId) {
@@ -79,25 +113,38 @@ public final class PluggyClient {
         "Response is successful, can't be parsed as an error response!");
     }
 
-    ResponseBody errorResponseBody = responseWithError.errorBody();
-    if (errorResponseBody == null) {
-      return null;
-    }
-
+    // extract the response body string to parse
     String errorResponseJson;
-    try {
-      errorResponseJson = errorResponseBody.string();
-    } catch (IOException e) {
-      throw new IOException("Could not convert error response to string", e);
+    try (ResponseBody errorResponseBody = responseWithError.errorBody()) {
+      assertNotNull(errorResponseBody, "responseWithError.body()");
+
+      try {
+        errorResponseJson = errorResponseBody.string();
+      } catch (IOException e) {
+        throw new IOException("Could not convert error response to string", e);
+      }
     }
 
-    ErrorResponse errorResponse = new Gson().fromJson(errorResponseJson, ErrorResponse.class);
+    // build the errorResponse object
+    ErrorResponse errorResponse;
+
+    try {
+      errorResponse = Utils.parseJsonResponse(errorResponseJson, ErrorResponse.class);
+    } catch (JsonSyntaxException e) {
+      // malformed or non-json response (ie. responded with 'Network error' string)
+      String rawResponseErrorMessage = buildResponseErrorMessage(responseWithError.raw(),
+        errorResponseJson);
+      errorResponse = new ErrorResponse();
+      errorResponse.setCode(responseWithError.code());
+      errorResponse.setMessage(rawResponseErrorMessage);
+    }
 
     return errorResponse;
   }
 
   /**
-   * Provides an API to build a PluggyClient instance while ensuring all parameters are defined and valid.
+   * Provides an API to build a PluggyClient instance while ensuring all parameters are defined and
+   * valid.
    */
   public static class PluggyClientBuilder {
 
@@ -134,10 +181,11 @@ public final class PluggyClient {
     }
 
     /**
-     * Opt-out from provided default ApiKeyAuthInterceptor, which takes care of apiKey authorization,
-     * by requesting a new apiKey token when it's not set, or by reactively refreshing an existing
-     * one and retrying a request in case of 401 or 403 unauthorized error responses.
-     *
+     * Opt-out from provided default ApiKeyAuthInterceptor, which takes care of apiKey
+     * authorization, by requesting a new apiKey token when it's not set, or by reactively
+     * refreshing an existing one and retrying a request in case of 401 or 403 unauthorized error
+     * responses.
+     * <p>
      * In case of opt-out, the client will have to provide it's own auth interceptor implementation,
      * which has to take care of including the "x-api-key" auth header to each http request.
      */
@@ -147,8 +195,8 @@ public final class PluggyClient {
     }
 
     /**
-     * Provides access to the OkHttpClient.Builder instance,
-     * for more complex builds and configurations (interceptors, SSL, etc.)
+     * Provides access to the OkHttpClient.Builder instance, for more complex builds and
+     * configurations (interceptors, SSL, etc.)
      */
     public OkHttpClient.Builder okHttpClientBuilder() {
       return okHttpClientBuilder;
@@ -209,7 +257,7 @@ public final class PluggyClient {
   /**
    * Request a new apiKey from API using defined clientId & clientSecret.
    */
-  public String authenticate() throws IOException {
+  public String authenticate() throws IOException, PluggyException {
     if (clientId == null || clientSecret == null) {
       throw new IllegalStateException(
         "Invalid state, both clientId and clientSecret must be defined!");
@@ -233,21 +281,24 @@ public final class PluggyClient {
       .addHeader("User-Agent", String.format("PluggyJava/%s", Utils.getSdkVersion()))
       .build();
 
-    AuthResponse authResponse;
+    String apiKey;
 
     try (okhttp3.Response response = this.httpClient.newCall(request).execute()) {
-      if (!response.isSuccessful()) {
-        throw new PluggyException(
-          "Pluggy Auth request failed, status: " + response.code() + ", message: " + response
-            .message());
-      }
+      try {
+        apiKey = AuthenticationHelper.extractApiKeyFromResponse(response);
+      } catch (IOException e) {
+        // unexpected IO exception
+        throw e;
+      } catch (Exception e) {
+        // non-successful or malformed JSON response
+        String pluggyResponseErrorMessage = buildResponseErrorMessage(
+          response);
 
-      ResponseBody responseBody = response.body();
-      assertNotNull(responseBody, "response.body()");
-      authResponse = gson.fromJson(responseBody.string(), AuthResponse.class);
+        throw new PluggyException(pluggyResponseErrorMessage, response, e);
+      }
     }
 
-    return authResponse.getApiKey();
+    return apiKey;
   }
 
   public PluggyApiService service() {

--- a/src/main/java/ai/pluggy/client/auth/AuthenticationHelper.java
+++ b/src/main/java/ai/pluggy/client/auth/AuthenticationHelper.java
@@ -1,0 +1,57 @@
+package ai.pluggy.client.auth;
+
+import ai.pluggy.client.PluggyClient;
+import ai.pluggy.client.response.AuthResponse;
+import ai.pluggy.exception.PluggyException;
+import ai.pluggy.utils.Utils;
+import com.google.gson.JsonSyntaxException;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+
+import java.io.IOException;
+
+import static ai.pluggy.utils.Asserts.assertNotNull;
+
+public class AuthenticationHelper {
+  
+  /**
+   * Extract the apiKey from the POST /auth response. If the response is invalid or malformed, throw
+   * an error instead.
+   *
+   * @param response - the 'POST /auth' response object
+   * @return apiKey string if could be parsed correctly, null if not
+   * @throws IllegalStateException if response is not successful
+   * @throws IOException           if response is malformed or could not be parsed correctly
+   * @throws JsonSyntaxException   if response body is not a JSON, or it is malformed
+   */
+  public static String extractApiKeyFromResponse(Response response)
+    throws IOException, JsonSyntaxException, PluggyException {
+    if (!response.isSuccessful()) {
+      // response is invalid due to not being successful
+      throw new PluggyException("Response was non-successful", response);
+    }
+
+    ResponseBody responseBody = response.peekBody(PluggyClient.ONE_MIB_BYTES);
+    assertNotNull(responseBody, "/auth response.body()");
+
+    String responseBodyString;
+    try {
+      responseBodyString = responseBody.string();
+    } catch (IOException e) {
+      throw new IOException("Unexpected IOException accessing response.body().string()", e);
+    }
+
+    AuthResponse authResponse;
+    try {
+      authResponse = Utils.parseJsonResponse(responseBodyString, AuthResponse.class);
+    } catch (JsonSyntaxException exception) {
+      // response didn't contain a valid JSON body, nothing to parse
+      throw new JsonSyntaxException(
+        String.format("/auth response is not a valid JSON body: '%s'", responseBodyString),
+        exception);
+    }
+
+    return authResponse.getApiKey();
+  }
+
+}

--- a/src/main/java/ai/pluggy/exception/PluggyException.java
+++ b/src/main/java/ai/pluggy/exception/PluggyException.java
@@ -3,24 +3,15 @@ package ai.pluggy.exception;
 import java.io.IOException;
 import okhttp3.Response;
 
-public class PluggyException extends IOException {
+public class PluggyException extends Exception {
 
-  public String apiMessage;
-  public Integer status;
-
-  public PluggyException(String message) {
-    super(message);
-  }
-
+  public final String apiMessage;
+  public final Integer status;
 
   public PluggyException(String message, Response response) {
     super(message);
     this.status = response.code();
     this.apiMessage = response.message();
-  }
-
-  public PluggyException(String message, Throwable cause) {
-    super(message, cause);
   }
 
   public PluggyException(String message, Response response, Throwable cause) {

--- a/src/main/java/ai/pluggy/utils/Utils.java
+++ b/src/main/java/ai/pluggy/utils/Utils.java
@@ -1,5 +1,7 @@
 package ai.pluggy.utils;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -18,5 +20,17 @@ public abstract class Utils {
     catch(IOException | XmlPullParserException e) {
       return "";
     }
+  }
+
+  public static <T> T parseJsonResponse(String responseBodyString, Class<T> clazz)
+    throws JsonSyntaxException {
+    if (responseBodyString == null) {
+      throw new JsonSyntaxException("Response body is null");
+    }
+    if (responseBodyString.length() == 0) {
+      throw new JsonSyntaxException("Response body is empty");
+    }
+
+    return new Gson().fromJson(responseBodyString, clazz);
   }
 }

--- a/src/test/java/ai/pluggy/client/unit/ClientParseErrorTest.java
+++ b/src/test/java/ai/pluggy/client/unit/ClientParseErrorTest.java
@@ -3,6 +3,7 @@ package ai.pluggy.client.unit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import ai.pluggy.client.PluggyClient;
 import ai.pluggy.client.response.ErrorResponse;
@@ -43,13 +44,15 @@ public class ClientParseErrorTest {
   }
 
   @Test
-  void clientParseError_malformedErrorResponse_fails() throws IOException {
+  void clientParseError_malformedJsonResponse_returnsErrorResponse() throws IOException {
     // simulate error response
     String malformedErrorJson = "{";
     Response<Object> errorResponse = Response
       .error(400, ResponseBody.create(malformedErrorJson, MediaType.parse("application/json")));
 
-    // expect parsed error response
-    assertThrows(JsonParseException.class, () -> client.parseError(errorResponse));
+    ErrorResponse parsedErrorResponse = client.parseError(errorResponse);
+    assertNotNull(parsedErrorResponse);
+    assertNotNull(parsedErrorResponse.getMessage());
+    assertTrue(parsedErrorResponse.getMessage().contains(malformedErrorJson));
   }
 }


### PR DESCRIPTION
 Also:
  * Reduce a significant amount of repeated logic
  * Handle errors in authentication requests properly as well
  * Improve of Pluggy API unexpected Network Error / Service Unavailable
  error responses handling with clearer error messages
  * Stop throwing unexpected errors when parsing a malformed JSON response,
  return a reasonable ErrorResponse object instead with a decent message.