### PR TITLE
fix: Fixing payeeMCC typo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>1.8.4</version>
+  <version>1.8.5</version>
 
   <packaging>jar</packaging>
 

--- a/src/main/java/ai/pluggy/client/response/TransactionCreditCardMetadata.java
+++ b/src/main/java/ai/pluggy/client/response/TransactionCreditCardMetadata.java
@@ -9,7 +9,7 @@ public class TransactionCreditCardMetadata {
     Integer installmentNumber;
     Integer totalInstallments;
     Double totalAmount;
-    Integer payeeMcc;
+    Integer payeeMCC;
     Date purchaseDate;
     String cardNumber;
     String billId;


### PR DESCRIPTION
In this PR, I am:
* Fixing payeeMCC typo to not serialize the value from the API response, which is payeeMCC).