### PR TITLE
feat: add missing options parameters to CreateConnectTokenRequest

### DIFF
--- a/src/main/java/ai/pluggy/client/request/CreateConnectTokenRequest.java
+++ b/src/main/java/ai/pluggy/client/request/CreateConnectTokenRequest.java
@@ -14,11 +14,11 @@ public class CreateConnectTokenRequest {
 
   public CreateConnectTokenRequest(String webhookUrl, String clientUserId) {
     this.itemId = null;
-    this.options = new Options(webhookUrl, clientUserId);
+    this.options = new Options(webhookUrl, clientUserId, null, null);
   }
 
   public CreateConnectTokenRequest(String itemId, String webhookUrl, String clientUserId) {
     this.itemId = itemId;
-    this.options = new Options(webhookUrl, clientUserId);
+    this.options = new Options(webhookUrl, clientUserId, null, null);
   }
 }

--- a/src/main/java/ai/pluggy/client/request/Options.java
+++ b/src/main/java/ai/pluggy/client/request/Options.java
@@ -9,4 +9,6 @@ public class Options {
 
   String webhookUrl;
   String clientUserId;
+  String oauthRedirectUri;
+  Boolean avoidDuplicates;
 }


### PR DESCRIPTION
I was using the SDK and noticed that the `Options` class for creating connect tokens was missing a couple of parameters compared to the current API docs. 

This PR adds `oauthRedirectUri` and `avoidDuplicates` to the `Options` payload.

**What changed:**
- Added the two missing fields to `Options.java`.
- Updated the internal call in `CreateConnectTokenRequest.java`.

**Note on compatibility:** I kept the original legacy constructors in `CreateConnectTokenRequest` exactly as they were so this doesn't introduce any breaking changes for existing users. The new fields just default to null if the old constructors are used.

Let me know if you need me to adjust anything!

- [x] Code compiles correctly.
- [x] Tests run successfully locally.