### PR TITLE
chore(ci): mask doppler secrets in github workflows (TRIN-2106)

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -46,7 +46,13 @@ jobs:
         run: doppler setup --token=${{ secrets.DOPPLER_TOKEN_PROD }} --no-prompt
 
       - name: Pass All Secrets to Next Steps
-        run: doppler secrets download --no-file --format=docker >> $GITHUB_ENV; 
+        run: |
+          while IFS='=' read -r key value; do
+            if [ -n "$key" ]; then
+              echo "::add-mask::$value"
+              echo "$key=$value" >> "$GITHUB_ENV"
+            fi
+          done < <(doppler secrets download --no-file --format=docker)
       
       - name: Check Test Env Variables
         run: echo PLUGGY_CLIENT_ID $PLUGGY_CLIENT_ID PLUGGY_BASE_URL $PLUGGY_BASE_URL

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,7 +38,13 @@ jobs:
         run: doppler setup --token=${{ secrets.DOPPLER_TOKEN_PROD }} --no-prompt
 
       - name: Pass All Secrets to Next Steps
-        run: doppler secrets download --no-file --format=docker >> $GITHUB_ENV; 
+        run: |
+          while IFS='=' read -r key value; do
+            if [ -n "$key" ]; then
+              echo "::add-mask::$value"
+              echo "$key=$value" >> "$GITHUB_ENV"
+            fi
+          done < <(doppler secrets download --no-file --format=docker)
       
       - name: Check Test Env Variables
         run: echo PLUGGY_CLIENT_ID $PLUGGY_CLIENT_ID PLUGGY_BASE_URL $PLUGGY_BASE_URL


### PR DESCRIPTION
## Summary
- Wrap `doppler secrets download` in a loop that emits `::add-mask::$value` for every secret before writing it to `$GITHUB_ENV`.
- Applies to `maven.yml` and `maven-publish.yml`.
- Goal: prevent Doppler secret values from leaking into Actions logs (TRIN-2106).

Note: both files have a `Check Test Env Variables` step that explicitly `echo`s `PLUGGY_CLIENT_ID` and `PLUGGY_BASE_URL`. With masking active, those values now render as `***` in the log — so the echo step is no longer a leak vector. (Whether to keep the echo step at all is a separate cleanup.)

## Test plan
- [ ] Open this PR and confirm the `Build & Test` workflow's `test` job (triggered by `pull_request: master`) runs cleanly and Doppler secret values appear as `***` in the job log.
- [ ] Confirm Maven `verify` still sees `PLUGGY_CLIENT_ID`, `PLUGGY_CLIENT_SECRET`, `PLUGGY_BASE_URL` (functional behavior unchanged).
- [ ] Same checks on the next release/`workflow_dispatch` run of `Maven Deploy to GitHub Packages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)