### PR TITLE
feat(identity): add PF/PJ identity fields exposed by Pluggy API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>1.8.5</version>
+  <version>1.9.0</version>
 
   <packaging>jar</packaging>
 

--- a/src/main/java/ai/pluggy/client/response/Address.java
+++ b/src/main/java/ai/pluggy/client/response/Address.java
@@ -14,4 +14,12 @@ public class Address {
   String postalCode;
   String primaryAddress;
   AddressType type;
+  /** District / neighborhood (bairro). */
+  String district;
+  /** IBGE municipality code (7 digits). The first two digits identify the Federation Unit. */
+  String ibgeTownCode;
+  /** Country code in alpha3 ISO-3166 format (e.g. 'BRA'). */
+  String countryCode;
+  /** Geographic coordinates of the address. */
+  GeographicCoordinates geographicCoordinates;
 }

--- a/src/main/java/ai/pluggy/client/response/BusinessOtherDocument.java
+++ b/src/main/java/ai/pluggy/client/response/BusinessOtherDocument.java
@@ -1,0 +1,21 @@
+package ai.pluggy.client.response;
+
+import java.util.Date;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Additional document for businesses headquartered abroad and not required to register a CNPJ.
+ */
+@Data
+@Builder
+public class BusinessOtherDocument {
+
+  /** Type of the document (e.g. 'EIN'). */
+  String type;
+  String number;
+  /** Issuing country in alpha3 ISO-3166 format. */
+  String country;
+  Date expirationDate;
+}

--- a/src/main/java/ai/pluggy/client/response/BusinessParty.java
+++ b/src/main/java/ai/pluggy/client/response/BusinessParty.java
@@ -1,0 +1,38 @@
+package ai.pluggy.client.response;
+
+import java.util.Date;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Partner or administrator of a business.
+ *
+ * Partners with less than 25% shareholding may be omitted by the institution.
+ */
+@Data
+@Builder
+public class BusinessParty {
+
+  BusinessPartyType type;
+  BusinessPartyPersonType personType;
+  BusinessPartyDocumentType documentType;
+  String documentNumber;
+  /** Issuing country of the document, alpha3 ISO-3166. */
+  String documentCountry;
+  Date documentExpirationDate;
+  Date documentIssueDate;
+  String documentAdditionalInfo;
+  /** Civil name. Required when personType is NATURAL_PERSON. */
+  String civilName;
+  String socialName;
+  /** Company name. Required when personType is LEGAL_ENTITY. */
+  String companyName;
+  String tradeName;
+  Date startDate;
+  /**
+   * Shareholding fraction between 0 and 1 (e.g. 0.51 represents 51%, 1 represents 100%).
+   * Required when type is PARTNER and the shareholding is 25% or higher.
+   */
+  Double shareholding;
+}

--- a/src/main/java/ai/pluggy/client/response/BusinessPartyDocumentType.java
+++ b/src/main/java/ai/pluggy/client/response/BusinessPartyDocumentType.java
@@ -1,0 +1,20 @@
+package ai.pluggy.client.response;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public enum BusinessPartyDocumentType {
+  @SerializedName("CPF")
+  CPF("CPF"),
+  @SerializedName("CNPJ")
+  CNPJ("CNPJ"),
+  @SerializedName("PASSPORT")
+  PASSPORT("PASSPORT"),
+  @SerializedName("OTHER_TRAVEL_DOCUMENT")
+  OTHER_TRAVEL_DOCUMENT("OTHER_TRAVEL_DOCUMENT");
+
+  @Getter
+  private String value;
+}

--- a/src/main/java/ai/pluggy/client/response/BusinessPartyPersonType.java
+++ b/src/main/java/ai/pluggy/client/response/BusinessPartyPersonType.java
@@ -1,0 +1,16 @@
+package ai.pluggy.client.response;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public enum BusinessPartyPersonType {
+  @SerializedName("NATURAL_PERSON")
+  NATURAL_PERSON("NATURAL_PERSON"),
+  @SerializedName("LEGAL_ENTITY")
+  LEGAL_ENTITY("LEGAL_ENTITY");
+
+  @Getter
+  private String value;
+}

--- a/src/main/java/ai/pluggy/client/response/BusinessPartyType.java
+++ b/src/main/java/ai/pluggy/client/response/BusinessPartyType.java
@@ -1,0 +1,16 @@
+package ai.pluggy.client.response;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public enum BusinessPartyType {
+  @SerializedName("PARTNER")
+  PARTNER("PARTNER"),
+  @SerializedName("ADMINISTRATOR")
+  ADMINISTRATOR("ADMINISTRATOR");
+
+  @Getter
+  private String value;
+}

--- a/src/main/java/ai/pluggy/client/response/GeographicCoordinates.java
+++ b/src/main/java/ai/pluggy/client/response/GeographicCoordinates.java
@@ -1,0 +1,17 @@
+package ai.pluggy.client.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Geographic coordinates in decimal degrees, WGS84 reference system.
+ */
+@Data
+@Builder
+public class GeographicCoordinates {
+
+  /** Between -90 and 90. */
+  Double latitude;
+  /** Between -180 and 180. */
+  Double longitude;
+}

--- a/src/main/java/ai/pluggy/client/response/IdentityResponse.java
+++ b/src/main/java/ai/pluggy/client/response/IdentityResponse.java
@@ -28,4 +28,27 @@ public class IdentityResponse {
   Date createdAt;
   Date updatedAt;
   String companyName;
+  /** Social name of the natural person (PF-only). */
+  String socialName;
+  /** Sex of the natural person (PF-only). */
+  Sex sex;
+  /** Marital status of the natural person (PF-only). */
+  MaritalStatus maritalStatus;
+  /** Nationality of the natural person (PF-only). */
+  Nationality nationality;
+  /** Other identification documents the natural person holds (PF-only). */
+  List<OtherDocument> otherDocuments;
+  /** Passport metadata for the natural person (PF-only). */
+  Passport passport;
+  /** Date the business was incorporated (PJ-only). */
+  Date incorporationDate;
+  /** Partners and administrators of the business (PJ-only). */
+  List<BusinessParty> parties;
+  /**
+   * Additional documents for businesses headquartered abroad and not required to register a CNPJ
+   * (PJ-only).
+   */
+  List<BusinessOtherDocument> businessOtherDocuments;
+  /** CNPJs of the financial institutions responsible for the customer cadastro. */
+  List<String> companiesCnpj;
 }

--- a/src/main/java/ai/pluggy/client/response/MaritalStatus.java
+++ b/src/main/java/ai/pluggy/client/response/MaritalStatus.java
@@ -1,0 +1,13 @@
+package ai.pluggy.client.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class MaritalStatus {
+
+  MaritalStatusCode code;
+  /** Free-text complement. Populated when code is OTHER. */
+  String additionalInfo;
+}

--- a/src/main/java/ai/pluggy/client/response/MaritalStatusCode.java
+++ b/src/main/java/ai/pluggy/client/response/MaritalStatusCode.java
@@ -1,0 +1,26 @@
+package ai.pluggy.client.response;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public enum MaritalStatusCode {
+  @SerializedName("SINGLE")
+  SINGLE("SINGLE"),
+  @SerializedName("MARRIED")
+  MARRIED("MARRIED"),
+  @SerializedName("WIDOWED")
+  WIDOWED("WIDOWED"),
+  @SerializedName("JUDICIALLY_SEPARATED")
+  JUDICIALLY_SEPARATED("JUDICIALLY_SEPARATED"),
+  @SerializedName("DIVORCED")
+  DIVORCED("DIVORCED"),
+  @SerializedName("STABLE_UNION")
+  STABLE_UNION("STABLE_UNION"),
+  @SerializedName("OTHER")
+  OTHER("OTHER");
+
+  @Getter
+  private String value;
+}

--- a/src/main/java/ai/pluggy/client/response/Nationality.java
+++ b/src/main/java/ai/pluggy/client/response/Nationality.java
@@ -1,0 +1,14 @@
+package ai.pluggy.client.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class Nationality {
+
+  Boolean hasBrazilianNationality;
+  List<OtherNationality> otherNationalities;
+}

--- a/src/main/java/ai/pluggy/client/response/NationalityDocument.java
+++ b/src/main/java/ai/pluggy/client/response/NationalityDocument.java
@@ -1,0 +1,18 @@
+package ai.pluggy.client.response;
+
+import java.util.Date;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class NationalityDocument {
+
+  String type;
+  String number;
+  String country;
+  Date issueDate;
+  Date expirationDate;
+  String additionalInfo;
+}

--- a/src/main/java/ai/pluggy/client/response/OtherDocument.java
+++ b/src/main/java/ai/pluggy/client/response/OtherDocument.java
@@ -1,0 +1,20 @@
+package ai.pluggy.client.response;
+
+import java.util.Date;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class OtherDocument {
+
+  OtherDocumentType type;
+  /** Free-text complement. Populated when type is OTHER. */
+  String typeAdditionalInfo;
+  String number;
+  String checkDigit;
+  /** Free-text complement, used to record the issuing authority (e.g. 'SSP/SP') when relevant. */
+  String additionalInfo;
+  Date expirationDate;
+}

--- a/src/main/java/ai/pluggy/client/response/OtherDocumentType.java
+++ b/src/main/java/ai/pluggy/client/response/OtherDocumentType.java
@@ -1,0 +1,22 @@
+package ai.pluggy.client.response;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public enum OtherDocumentType {
+  @SerializedName("CNH")
+  CNH("CNH"),
+  @SerializedName("RG")
+  RG("RG"),
+  @SerializedName("NIF")
+  NIF("NIF"),
+  @SerializedName("RNE")
+  RNE("RNE"),
+  @SerializedName("OTHER")
+  OTHER("OTHER");
+
+  @Getter
+  private String value;
+}

--- a/src/main/java/ai/pluggy/client/response/OtherNationality.java
+++ b/src/main/java/ai/pluggy/client/response/OtherNationality.java
@@ -1,0 +1,15 @@
+package ai.pluggy.client.response;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class OtherNationality {
+
+  /** Country code in alpha3 ISO-3166 format. */
+  String countryCode;
+  List<NationalityDocument> documents;
+}

--- a/src/main/java/ai/pluggy/client/response/Passport.java
+++ b/src/main/java/ai/pluggy/client/response/Passport.java
@@ -1,0 +1,17 @@
+package ai.pluggy.client.response;
+
+import java.util.Date;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class Passport {
+
+  String number;
+  /** Issuing country in alpha3 ISO-3166 format. */
+  String country;
+  Date issueDate;
+  Date expirationDate;
+}

--- a/src/main/java/ai/pluggy/client/response/PhoneNumber.java
+++ b/src/main/java/ai/pluggy/client/response/PhoneNumber.java
@@ -7,4 +7,12 @@ public class PhoneNumber {
 
   PhoneNumberType type;
   String value;
+  /** International dialing code (DDI). Populated when different from '55'. */
+  String countryCallingCode;
+  /** Area code (DDD) of the phone. */
+  String areaCode;
+  /** Extension number, when part of the phone identification. */
+  String extension;
+  /** Additional info related to the source phone type. */
+  String additionalInfo;
 }

--- a/src/main/java/ai/pluggy/client/response/Sex.java
+++ b/src/main/java/ai/pluggy/client/response/Sex.java
@@ -1,0 +1,18 @@
+package ai.pluggy.client.response;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public enum Sex {
+  @SerializedName("FEMALE")
+  FEMALE("FEMALE"),
+  @SerializedName("MALE")
+  MALE("MALE"),
+  @SerializedName("OTHER")
+  OTHER("OTHER");
+
+  @Getter
+  private String value;
+}


### PR DESCRIPTION
## Summary

Mirrors the Identity additions on the API side into the Java SDK. All new fields are optional / nullable — existing consumers keep working unchanged, and Gson tolerates them being absent on the wire.

## What changes

### Extended classes

**`IdentityResponse`** gains 10 optional fields:
- PF — `socialName`, `sex`, `maritalStatus`, `nationality`, `otherDocuments`, `passport`
- PJ — `incorporationDate`, `parties`, `businessOtherDocuments`
- Shared — `companiesCnpj`

**`PhoneNumber`** gains `countryCallingCode`, `areaCode`, `extension`, `additionalInfo`.

**`Address`** gains `district`, `ibgeTownCode`, `countryCode`, `geographicCoordinates`.

### New types (15)

- `Sex` (enum)
- `MaritalStatus` + `MaritalStatusCode` enum
- `Nationality` + `OtherNationality` + `NationalityDocument`
- `OtherDocument` + `OtherDocumentType` enum
- `Passport`
- `BusinessParty` + `BusinessPartyType` / `BusinessPartyPersonType` / `BusinessPartyDocumentType` enums
- `BusinessOtherDocument`
- `GeographicCoordinates`

Every enum follows the existing project pattern (Gson `@SerializedName` + Lombok `@AllArgsConstructor` / `@Getter`); every value class uses `@Data` + `@Builder` for consistency with `Address`, `IdentityResponse`, etc.

## Out of scope

The Java SDK has historically not exposed `qualifications` or `financialRelationships`, so the new sub-fields that live under those (`economicActivities`, `informedRevenue`, `portabilitiesReceived`, `paychecksBankLink`, `informedPatrimony.date`, procurator's `documentNumber/documentType`, etc.) are not in this PR. They need the missing parent types introduced first — better as a follow-up that also catches the Java SDK up on the pre-existing fields.

## Test plan

- [x] `mvn compile` — clean.
- [x] `mvn test-compile` — clean.
- [x] `mvn test` — unit tests (`ai.pluggy.client.unit.*`) pass. Integration tests fail at `BaseApiIntegrationTest.checkEnvErrors` because they require real API credentials in env vars — pre-existing, unrelated to this PR.
- [ ] Smoke test against a deployed API 0.24 item that returns the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)