### PR TITLE
feat(investment): add missing API fields issueDate, purchaseDate, issuerCNPJ

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -10,13 +10,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 1.8
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          distribution: 'temurin'
 
       - name: Build with Maven
         run: mvn -B package --file pom.xml
@@ -24,15 +24,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 1.8
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          distribution: 'temurin'
           
       - name: Publish to GitHub Packages Apache Maven
-        run: mvn deploy -Dmaven.test.skip.exec -s $GITHUB_WORKSPACE/settings.xml # skip tests in this step
+        run: mvn deploy -Dmaven.test.skip=true
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_USERNAME: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -5,7 +5,7 @@ name: Maven Deploy to GitHub Packages
 on:
   release:
     types: [created]
-
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,41 +17,12 @@ jobs:
         with:
           java-version: 1.8
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          settings-path: ${{ github.workspace }} # location for the settings.xml file
 
       - name: Build with Maven
         run: mvn -B package --file pom.xml
-  test:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v1
-
-      - name: Login in Doppler
-        run: doppler setup --token=${{ secrets.DOPPLER_TOKEN_PROD }} --no-prompt
-
-      - name: Pass All Secrets to Next Steps
-        run: doppler secrets download --no-file --format=docker >> $GITHUB_ENV; 
-      
-      - name: Check Test Env Variables
-        run: echo PLUGGY_CLIENT_ID $PLUGGY_CLIENT_ID PLUGGY_BASE_URL $PLUGGY_BASE_URL
-        env:
-          PLUGGY_CLIENT_ID: ${{ env.PLUGGY_CLIENT_ID }}
-          PLUGGY_CLIENT_SECRET: ${{ env.PLUGGY_CLIENT_SECRET }}
-          PLUGGY_BASE_URL: ${{ env.PLUGGY_BASE_URL }}
-
-      - name: Integration Tests
-        run: mvn -B verify --file pom.xml
-        env:
-          PLUGGY_CLIENT_ID: ${{ env.PLUGGY_CLIENT_ID }}
-          PLUGGY_CLIENT_SECRET: ${{ env.PLUGGY_CLIENT_SECRET }}
-          PLUGGY_BASE_URL: ${{ env.PLUGGY_BASE_URL }}
   deploy:
     runs-on: ubuntu-latest
-    needs: [build, test]
+    needs: [build]
     steps:
       - uses: actions/checkout@v2
 
@@ -60,7 +31,6 @@ jobs:
         with:
           java-version: 1.8
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          settings-path: ${{ github.workspace }} # location for the settings.xml file
           
       - name: Publish to GitHub Packages Apache Maven
         run: mvn deploy -Dmaven.test.skip.exec -s $GITHUB_WORKSPACE/settings.xml # skip tests in this step

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -10,13 +10,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v1
         with:
           java-version: 1.8
-          distribution: 'temurin'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
 
       - name: Build with Maven
         run: mvn -B package --file pom.xml
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v1
         with:
           java-version: 1.8
-          distribution: 'temurin'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           
       - name: Publish to GitHub Packages Apache Maven
         run: mvn deploy -Dmaven.test.skip=true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,50 @@
+name: Publish to GitHub Packages
+
+on:
+  release:
+    types: [created]
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Create Maven settings
+        run: |
+          mkdir -p ~/.m2
+          cp .m2/settings.xml ~/.m2/settings.xml
+
+      - name: Build with Maven
+        run: mvn clean compile
+
+      - name: Package
+        run: mvn package -DskipTests
+
+      - name: Publish to GitHub Packages
+        run: mvn deploy -DskipTests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}

--- a/.m2/settings.xml
+++ b/.m2/settings.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <servers>
+    <server>
+      <id>github</id>
+      <username>${env.GITHUB_ACTOR}</username>
+      <password>${env.GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>1.8.3</version>
+  <version>1.8.4</version>
 
   <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>1.8.4</version>
+  <version>1.8.5</version>
 
   <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
     <repository>
       <id>github</id>
       <name>GitHub Packages</name>
-      <url>https://maven.pkg.github.com/pluggyai/pluggy-java</url>
+      <url>https://maven.pkg.github.com/Orbi-Finance/pluggy-java</url>
     </repository>
   </distributionManagement>
 </project>

--- a/src/main/java/ai/pluggy/client/response/Investment.java
+++ b/src/main/java/ai/pluggy/client/response/Investment.java
@@ -36,7 +36,12 @@ public class Investment {
   String amountProfit = null;
   Double amountWithdrawal;
   String issuer;
+  String issuerCNPJ;
+  /** @deprecated field was misnamed — use {@link #issueDate} instead; this field is always null */
+  @Deprecated
   Date issuerDate;
+  Date issueDate;
+  Date purchaseDate;
   InvestmentStatus status;
   /**
    * @deprecated use

--- a/src/main/java/ai/pluggy/client/response/Transaction.java
+++ b/src/main/java/ai/pluggy/client/response/Transaction.java
@@ -14,6 +14,7 @@ public class Transaction {
   String date;
   Double balance;
   String category;
+  String categoryId;
   String providerCode;
   TransactionStatus status;
   PaymentData paymentData;

--- a/src/main/java/ai/pluggy/client/response/TransactionCreditCardMetadata.java
+++ b/src/main/java/ai/pluggy/client/response/TransactionCreditCardMetadata.java
@@ -9,7 +9,7 @@ public class TransactionCreditCardMetadata {
     Integer installmentNumber;
     Integer totalInstallments;
     Double totalAmount;
-    Integer payeeMcc;
+    Integer payeeMCC;
     Date purchaseDate;
     String cardNumber;
     String billId;


### PR DESCRIPTION
## Problem

The Pluggy REST API returns three fields in the Investment response that are not currently mapped in the `Investment` DTO, causing them to be silently discarded by Gson (which uses `FieldNamingPolicy.IDENTITY` — exact byte-for-byte field name matching).

### Fields affected

| API JSON key | Current SDK field | Result |
|---|---|---|
| `issueDate` | `issuerDate` (misnamed) | Always `null` — key mismatch |
| `purchaseDate` | *(missing)* | Always `null` — discarded |
| `issuerCNPJ` | *(missing)* | Always `null` — discarded |

The existing `issuerDate` field has been misnamed since it was introduced: the API key is `issueDate` (no "r"), so Gson never populates it.

## Solution

- Add `issueDate` (`Date`) — correct name, maps the investment emission/issue date
- Add `purchaseDate` (`Date`) — maps the investor's application/purchase date
- Add `issuerCNPJ` (`String`) — maps the CNPJ of the issuing institution
- Keep `issuerDate` as `@Deprecated` for backward compatibility (it was always null, so removing it would only surface pre-existing bugs in downstream code)

## Verified against live API

Confirmed against two investment types:
- **CDB (NU FINANCEIRA)**: `issueDate: "2026-02-06"`, `purchaseDate: "2026-02-06"`, `issuerCNPJ: "30.680.829/0001-43"`
- **Tesouro IPCA+ 2045**: `issueDate: "2022-05-03"`, `purchaseDate: "2022-05-03"`, `issuerCNPJ: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)