### PR TITLE
feat(investment): add missing API fields issueDate, purchaseDate, issuerCNPJ

### DIFF
--- a/src/main/java/ai/pluggy/client/response/Investment.java
+++ b/src/main/java/ai/pluggy/client/response/Investment.java
@@ -36,7 +36,12 @@ public class Investment {
   String amountProfit = null;
   Double amountWithdrawal;
   String issuer;
+  String issuerCNPJ;
+  /** @deprecated The API key is {@code issueDate} — this field is always {@code null} due to a naming mismatch. Use {@link #issueDate} instead. */
+  @Deprecated
   Date issuerDate;
+  Date issueDate;
+  Date purchaseDate;
   InvestmentStatus status;
   /**
    * @deprecated use


### PR DESCRIPTION
## Problem

The Pluggy REST API returns three Investment fields that are not mapped in the `Investment` DTO. The SDK uses `FieldNamingPolicy.IDENTITY` (Gson), which requires exact byte-for-byte field name matches — misnamed or missing Java fields are silently discarded.

### Fields affected

| API JSON key | Current SDK field | Effect |
|---|---|---|
| `issueDate` | `issuerDate` (misnamed — extra `r`) | Always `null` |
| `purchaseDate` | *(not present)* | Always `null` |
| `issuerCNPJ` | *(not present)* | Always `null` |

`issuerDate` was misnamed when first introduced. Because `FieldNamingPolicy.IDENTITY` requires an exact match, the API key `issueDate` never maps to the Java field `issuerDate`.

## Solution

- Add `issueDate` (`Date`) — correct name for the instrument's emission/issue date
- Add `purchaseDate` (`Date`) — date the investor purchased/applied for the investment
- Add `issuerCNPJ` (`String`) — CNPJ of the issuing institution
- Mark existing `issuerDate` as `@Deprecated` with a migration note (kept for backward compatibility — removing it would surface the pre-existing null in callers, not a real regression)

## Verified against live API

Tested against two investment types from real API responses:

**CDB (NU FINANCEIRA):**
```json
"issueDate": "2026-02-06T03:00:00.000Z",
"purchaseDate": "2026-02-06T03:00:00.000Z",
"issuerCNPJ": "30.680.829/0001-43"
```

**Tesouro IPCA+ 2045:**
```json
"issueDate": "2022-05-03T03:00:00.000Z",
"purchaseDate": "2022-05-03T03:00:00.000Z",
"issuerCNPJ": null
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)