### PR TITLE
fix: derive User-Agent version from pom at build time

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <!-- Test Surefire Plugin -->
       <plugin>

--- a/src/main/java/ai/pluggy/client/PluggyClient.java
+++ b/src/main/java/ai/pluggy/client/PluggyClient.java
@@ -9,6 +9,7 @@ import ai.pluggy.client.auth.EncryptedParametersInterceptor;
 import ai.pluggy.client.response.ErrorResponse;
 import ai.pluggy.exception.PluggyException;
 import ai.pluggy.utils.Utils;
+import ai.pluggy.utils.Version;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -292,7 +293,7 @@ public final class PluggyClient {
         .post(body)
         .addHeader("content-type", "application/json")
         .addHeader("cache-control", "no-cache")
-        .addHeader("User-Agent", "PluggyJava/0.16.2")
+        .addHeader("User-Agent", Version.USER_AGENT)
         .build();
 
     String apiKey;

--- a/src/main/java/ai/pluggy/client/auth/ApiKeyAuthInterceptor.java
+++ b/src/main/java/ai/pluggy/client/auth/ApiKeyAuthInterceptor.java
@@ -2,6 +2,7 @@ package ai.pluggy.client.auth;
 
 import static ai.pluggy.utils.Asserts.assertNotNull;
 
+import ai.pluggy.utils.Version;
 import com.google.gson.Gson;
 
 import java.io.IOException;
@@ -114,8 +115,7 @@ public class ApiKeyAuthInterceptor implements Interceptor {
     // override the apiKey of the original request with the new one
     return originalRequest.newBuilder()
       .header(X_API_KEY_HEADER, apiKey)
-      // TOOD: add dynamic version
-      .header("User-Agent", "PluggyJava/0.16.2")
+      .header("User-Agent", Version.USER_AGENT)
       .build();
   }
 

--- a/src/main/java/ai/pluggy/utils/Version.java
+++ b/src/main/java/ai/pluggy/utils/Version.java
@@ -1,0 +1,24 @@
+package ai.pluggy.utils;
+
+import java.io.InputStream;
+import java.util.Properties;
+import lombok.SneakyThrows;
+
+public final class Version {
+
+  public static final String SDK_VERSION = loadSdkVersion();
+  public static final String USER_AGENT =
+      "PluggyJava/" + SDK_VERSION + " (Java " + System.getProperty("java.version") + ")";
+
+  private Version() {
+  }
+
+  @SneakyThrows
+  private static String loadSdkVersion() {
+    Properties props = new Properties();
+    try (InputStream in = Version.class.getResourceAsStream("/pluggy-version.properties")) {
+      props.load(in);
+    }
+    return props.getProperty("version");
+  }
+}

--- a/src/main/resources/pluggy-version.properties
+++ b/src/main/resources/pluggy-version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/src/test/java/ai/pluggy/client/unit/VersionTest.java
+++ b/src/test/java/ai/pluggy/client/unit/VersionTest.java
@@ -1,0 +1,27 @@
+package ai.pluggy.client.unit;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.pluggy.utils.Version;
+import org.junit.jupiter.api.Test;
+
+public class VersionTest {
+
+  @Test
+  void sdkVersion_isResolvedFromPom_notTheLiteralPlaceholder() {
+    assertNotNull(Version.SDK_VERSION);
+    assertTrue(Version.SDK_VERSION.matches("\\d+\\.\\d+\\.\\d+(-\\w+)?"),
+        "SDK_VERSION should look like a semver, got: '" + Version.SDK_VERSION
+            + "'. If it's '${project.version}', Maven resource filtering is broken.");
+  }
+
+  @Test
+  void userAgent_followsExpectedFormat() {
+    assertTrue(Version.USER_AGENT.startsWith("PluggyJava/" + Version.SDK_VERSION + " (Java "),
+        "USER_AGENT should start with 'PluggyJava/<version> (Java ', got: '"
+            + Version.USER_AGENT + "'");
+    assertTrue(Version.USER_AGENT.endsWith(")"),
+        "USER_AGENT should end with ')', got: '" + Version.USER_AGENT + "'");
+  }
+}


### PR DESCRIPTION
## Summary
- The User-Agent header was hardcoded to `PluggyJava/0.16.2` in both `PluggyClient.authenticate` and `ApiKeyAuthInterceptor.requestWithAuth`, stale against the actual pom version (`1.9.0`). API-side logs and analytics have been seeing the wrong SDK version.
- Maven resource filtering now injects `${project.version}` into a new `pluggy-version.properties` at build time. A `ai.pluggy.utils.Version` utility loads it once and exposes `Version.USER_AGENT`.
- User-Agent now resolves to `PluggyJava/<version> (Java <java.version>)`, giving the API visibility into both SDK and consumer JVM.
- Removed the `// TOOD: add dynamic version` (sic) note in `ApiKeyAuthInterceptor` that flagged this exact debt.

## Test plan
- [x] `mvn -B test` — 6/6 unit tests pass (4 existing + 2 new in `VersionTest`)
- [x] `mvn -B verify` — 39 integration tests pass, 0 failures
- [x] Verified `target/classes/pluggy-version.properties` contains `version=1.9.0` after build (Maven filtering works as expected)
- [x] `VersionTest.sdkVersion_isResolvedFromPom_notTheLiteralPlaceholder` guards against future filtering regressions