### PR TITLE
fix(deps): bump gson from 2.8.0 to 2.11.0 (CVE-2022-25647)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.0</version>
+      <version>2.11.0</version>
     </dependency>
 
     <!-- Lombok -->


### PR DESCRIPTION
## Summary
Bumps `com.google.code.gson:gson` from `2.8.0` to `2.11.0`, closing [Dependabot alert #11](https://github.com/pluggyai/pluggy-java/security/dependabot/11) (**high** severity).

- CVE: [CVE-2022-25647](https://nvd.nist.gov/vuln/detail/CVE-2022-25647) — Deserialization of Untrusted Data in Gson
- Advisory: [GHSA-4jrv-ppp4-jm57](https://github.com/advisories/GHSA-4jrv-ppp4-jm57)
- First patched version is `2.8.9`. Bumped all the way to `2.11.0` (current stable on the `2.x` line) so we don't immediately drift back into the long tail.

Gson `2.x` is API-stable. The SDK only uses `Gson`, `GsonBuilder`, `FieldNamingPolicy`, `JsonSyntaxException`, and `TypeToken` — all unchanged between 2.8.0 and 2.11.0.

## Test plan
- [x] `mvn -B test` — unit tests pass
- [x] `mvn -B verify` — 39 integration tests pass, 0 failures (hits live API; covers Item/Account/Transaction/Investment/Connector deserialization paths via `converter-gson`)