### PR TITLE
fix(ci): grant packages:write to maven-publish deploy job

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -70,6 +70,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [build, test]
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add explicit `permissions: { contents: read, packages: write }` to the `deploy` job in `.github/workflows/maven-publish.yml`.
- Fixes recent `HTTP 403 Forbidden` failures from `mvn deploy` against `maven.pkg.github.com/pluggyai/pluggy-java`.

## Why it broke "out of nowhere"
The job had no `permissions:` block, so `GITHUB_TOKEN` inherited the org/repo default. GitHub no longer grants `packages: write` by default in many configurations — once that default tightens, the token is valid but cannot push packages, and the deploy step gets a 403. `release.yml` already declares its own permissions; this change brings `maven-publish.yml` in line with that pattern.

## Test plan
- [ ] Re-run the `Maven Deploy to GitHub Packages` workflow via `workflow_dispatch` with `tag_version: v1.9.0` and confirm the `deploy` job succeeds.
- [ ] Verify the `1.9.0` jar appears under https://github.com/pluggyai/pluggy-java/packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)