### PR TITLE
chore(ci): add PR title validation workflow

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,36 @@
+name: PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+    branches:
+      - master
+
+jobs:
+  validate:
+    name: Validate Conventional Commits title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            chore
+            docs
+            style
+            refactor
+            test
+            build
+            ci
+            revert
+          requireScope: false


### PR DESCRIPTION
## Summary
Ports `pr-title.yml` from `pluggy-node`. Runs on every PR targeting `master` and validates the title against Conventional Commits via [`amannn/action-semantic-pull-request@v6.1.1`](https://github.com/amannn/action-semantic-pull-request).

Allowed types: `feat`, `fix`, `perf`, `chore`, `docs`, `style`, `refactor`, `test`, `build`, `ci`, `revert`. Scope is optional.

The existing commit history in this repo already follows this style informally (`fix:`, `feat(identity):`, `chore(deps):`, etc.); the workflow just makes it enforced so titles can't drift.

## Test plan
- [ ] After merge, open a PR with a non-conforming title (e.g. `update stuff`) and verify the check fails
- [ ] Open a PR with `feat: add thing` and verify the check passes
