### PR TITLE
chore(test): use RequestCatcher webhook URLs in integration tests

### DIFF
--- a/src/test/java/ai/pluggy/client/integration/CreateItemTest.java
+++ b/src/test/java/ai/pluggy/client/integration/CreateItemTest.java
@@ -39,7 +39,7 @@ public class CreateItemTest extends BaseApiIntegrationTest {
 
         // run request with 'connectorId', 'parameters', 'webhookUrl', 'clientUserId',
         // params
-        String webhookUrl = "https://www.test.com/";
+        String webhookUrl = "https://pluggy-java-tests.requestcatcher.com/create";
         String clientUserId = "clientUserId";
         CreateItemRequest createItemRequestWithWebhook = new CreateItemRequest(connectorId,
                 parametersMap, webhookUrl, clientUserId);

--- a/src/test/java/ai/pluggy/client/integration/UpdateItemTest.java
+++ b/src/test/java/ai/pluggy/client/integration/UpdateItemTest.java
@@ -30,7 +30,7 @@ public class UpdateItemTest extends BaseApiIntegrationTest {
     ItemResponse itemResponse = createPluggyBankItem(client);
 
     // build update item request
-    String newWebhookUrl = "https://www.test.com";
+    String newWebhookUrl = "https://pluggy-java-tests.requestcatcher.com/update-before";
     String newClientUserId = "clientUserId";
     UpdateItemRequest updateItemRequest = UpdateItemRequest.builder()
         .webhookUrl(newWebhookUrl)
@@ -63,7 +63,7 @@ public class UpdateItemTest extends BaseApiIntegrationTest {
     ItemResponse createdItemResponse = createPluggyBankItem(client);
 
     // build update item request
-    String newWebhookUrl = "https://www.test2.com";
+    String newWebhookUrl = "https://pluggy-java-tests.requestcatcher.com/update-after";
     String newClientUserId = "clientUserId";
     UpdateItemRequest updateItemRequest = UpdateItemRequest.builder()
         .webhookUrl(newWebhookUrl)

--- a/src/test/java/ai/pluggy/client/integration/helper/ItemHelper.java
+++ b/src/test/java/ai/pluggy/client/integration/helper/ItemHelper.java
@@ -45,9 +45,9 @@ public class ItemHelper {
     log.info("Creating item execution for connector id '" + connectorId + "'...");
     // run request with 'connectorId', 'parameters' params
     CreateItemRequest createItemRequest = new CreateItemRequest(
-      connectorId, 
-      parametersMap, 
-      "https://webhookUrl.pluggy.ai", 
+      connectorId,
+      parametersMap,
+      "https://pluggy-java-tests.requestcatcher.com/test",
       "clientUserId"
     );
 


### PR DESCRIPTION
## Problem

The daily scheduled `Build & Test` run has been failing since ~2026-06-01. ~10 integration test classes fail in `setUp` with:

```
java.lang.Error: Create item request responded with error, code=400,
message='Webhook url is a reserved placeholder and cannot be used'
```

## Root cause

This is an **API-side change**, not a repo regression: the last green scheduled run (May 31) and the first red one (Jun 1) ran the same `master` with no code change in between (runtime dropped from ~6min to ~1.5min because the tests now abort early in `setUp`).

Around Jun 1 the API started rejecting reserved/placeholder webhook URLs. The tests hardcoded such URLs:
- `helper/ItemHelper.java` → `https://webhookUrl.pluggy.ai` (used by `createPluggyBankItem`, so it broke the `setUp` of almost every item-dependent test)
- `CreateItemTest` / `UpdateItemTest` → `https://www.test.com` / `https://www.test2.com` (no longer accepted either)

Tests that don't create items (connectors, categories, auth, connect token) keep passing.

## Fix

Replace the hardcoded placeholders with public, reachable HTTPS **RequestCatcher** endpoints, as recommended by the [Pluggy webhook docs](https://docs.pluggy.ai/docs/webhooks) for testing. Distinct paths are used where the assertions compare URLs (`UpdateItemTest`). The negative `http://www.test.com` case (which tests rejection of non-HTTPS) is left untouched.

## Validation
- ✅ `mvn test-compile` (JDK 11)
- ⏳ Integration tests run against the live API with Doppler credentials in CI — this PR's `Build & Test` run will confirm the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)