### PR TITLE
fix(deps): bump gson to 2.11.0 to patch CVE-2022-25647

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.0</version>
+      <version>2.11.0</version>
     </dependency>
 
     <!-- Lombok -->


### PR DESCRIPTION
## What

Bumps the direct `com.google.code.gson:gson` dependency from **2.8.0** → **2.11.0**.

## Why

Resolves Dependabot alert #11 — **CVE-2022-25647 / GHSA-4jrv-ppp4-jm57** (high): *Deserialization of Untrusted Data in Gson*, affecting `< 2.8.9`.

gson is declared directly in `pom.xml`, so the transitive copy pulled by `retrofit:converter-gson` does not shadow it — the direct declaration must be bumped.

## Version choice

`2.11.0` over the minimal `2.8.9`: mature, widely adopted, retains the Java 8 baseline the SDK targets, and rolls up every fix since. `FieldNamingPolicy.IDENTITY` semantics (the byte-for-byte field-matching the DTOs rely on) are unchanged across these versions.

## Verification

- `mvn -B dependency:tree` confirms `gson:2.11.0` resolved
- `mvn -B package` → BUILD SUCCESS, 4/4 unit tests pass