### PR TITLE
feat(investment): add issueDate, purchaseDate, issuerCNPJ fields

### DIFF
--- a/src/main/java/ai/pluggy/client/response/Investment.java
+++ b/src/main/java/ai/pluggy/client/response/Investment.java
@@ -36,7 +36,16 @@ public class Investment {
   String amountProfit = null;
   Double amountWithdrawal;
   String issuer;
+  String issuerCNPJ;
+  /**
+   * @deprecated the API field is {@code issueDate}; this misnamed field always
+   *             resolves to {@code null} under Gson's {@code IDENTITY} naming.
+   *             Use {@link #issueDate} instead.
+   */
+  @Deprecated
   Date issuerDate;
+  Date issueDate;
+  Date purchaseDate;
   InvestmentStatus status;
   /**
    * @deprecated use


### PR DESCRIPTION
## Problem

The Pluggy API returns three `Investment` fields that the DTO does not map. The SDK uses Gson `FieldNamingPolicy.IDENTITY`, so a Java field name must match the API JSON key **byte-for-byte** — unmapped or misnamed fields silently resolve to `null`.

| API JSON key | Before | Effect |
|---|---|---|
| `issueDate` | mapped as `issuerDate` (extra `r`) | always `null` |
| `purchaseDate` | not present | always `null` |
| `issuerCNPJ` | not present | always `null` |

## Change

- Add `issueDate` (`Date`), `purchaseDate` (`Date`), `issuerCNPJ` (`String`).
- Keep the misnamed `issuerDate` but mark it `@Deprecated`, pointing to `issueDate` — no breaking change for existing consumers.

## Casing / types verified against the spec

Checked `api.pluggy.ai/oas3.json` → `components.schemas.Investment.properties`:

- `issueDate`: `string` / `date-time` → `Date`
- `purchaseDate`: `string` / `date-time` → `Date`
- `issuerCNPJ`: `string` (CNPJ upper-case in the spec) → `String`

`issueDate`/`purchaseDate` use `Date` to match the existing `date`/`dueDate`/`issuerDate` mapping.

## Verification

`mvn -B package` → BUILD SUCCESS, 4/4 unit tests pass.