### PR TITLE
feat: add operationTypeAdditionalInfo to Transaction

### DIFF
--- a/src/main/java/ai/pluggy/client/response/Transaction.java
+++ b/src/main/java/ai/pluggy/client/response/Transaction.java
@@ -22,5 +22,6 @@ public class Transaction {
   TransactionType type;
   Merchant merchant;
   String operationType;
+  String operationTypeAdditionalInfo;
   String providerId;
 }


### PR DESCRIPTION
Adds the `operationTypeAdditionalInfo` field to the Transaction model — a free-form complement to `operationType`, returned by the API for Open Finance connectors. It varies by institution (a sub-type code or a description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
