### PR TITLE
feat(version): add Java version suffix to User-Agent

### DIFF
--- a/src/main/java/ai/pluggy/utils/Version.java
+++ b/src/main/java/ai/pluggy/utils/Version.java
@@ -21,9 +21,12 @@ public final class Version {
     return VERSION;
   }
 
-  /** {@code User-Agent} header value, e.g. {@code "PluggyJava/1.11.0"}. */
+  /**
+   * {@code User-Agent} header value, e.g. {@code "PluggyJava/1.11.0 (Java 1.8.0_292)"}. The Java
+   * version suffix gives the API visibility into the consumer's JVM.
+   */
   public static String userAgent() {
-    return "PluggyJava/" + VERSION;
+    return "PluggyJava/" + VERSION + " (Java " + System.getProperty("java.version") + ")";
   }
 
   private static String load() {

--- a/src/test/java/ai/pluggy/utils/VersionTest.java
+++ b/src/test/java/ai/pluggy/utils/VersionTest.java
@@ -21,4 +21,13 @@ public class VersionTest {
   public void userAgent_hasExpectedPrefix() {
     assertTrue(Version.userAgent().startsWith("PluggyJava/"));
   }
+
+  @Test
+  public void userAgent_includesJavaVersionSuffix() {
+    // e.g. "PluggyJava/1.11.0 (Java 1.8.0_292)" — gives the API visibility into the consumer's JVM.
+    String userAgent = Version.userAgent();
+    assertTrue(userAgent.startsWith("PluggyJava/" + Version.get() + " (Java "),
+        "userAgent should start with 'PluggyJava/<version> (Java ', got: '" + userAgent + "'");
+    assertTrue(userAgent.endsWith(")"), "userAgent should end with ')', got: '" + userAgent + "'");
+  }
 }


### PR DESCRIPTION
## Summary

- `User-Agent` becomes `PluggyJava/<version> (Java <java.version>)` (was `PluggyJava/<version>`), giving the API visibility into the consumer's JVM.
- New `VersionTest` assertion covers the suffix.

## Test plan
- [x] `mvn -B package` → BUILD SUCCESS, VersionTest 3/3