### PR TITLE
chore(deps): limit Dependabot to minor + patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,17 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Only minor + patch updates. Major bumps (e.g. actions/checkout v2 -> v7)
+    # are breaking and reviewed manually, not via Dependabot.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "weekly"
+    # Only minor + patch updates. Major bumps (e.g. okhttp 4 -> 5, junit 5 -> 6)
+    # are breaking and reviewed manually, not via Dependabot.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

- Ignore `version-update:semver-major` on both the `maven` and `github-actions` ecosystems in `dependabot.yml`.
- Dependabot now opens only minor + patch PRs; major (breaking) upgrades are handled manually when intended.

## Why

Major bumps (actions/checkout v2→v7, okhttp 4→5, junit 5→6, ...) are breaking and risky to merge blindly, and create review noise.

## Test plan
- [x] `dependabot.yml` is valid YAML