### PR TITLE
fix(ci): revert setup-java and doppler action bumps to restore Build & Test

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v1
         with:
           java-version: 1.8
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v4
+        uses: dopplerhq/cli-action@v1
 
       - name: Login in Doppler
         run: doppler setup --token=${{ secrets.DOPPLER_TOKEN_PROD }} --no-prompt


### PR DESCRIPTION
## Summary

- Revert `actions/setup-java` v5 → v1 and `dopplerhq/cli-action` v4 → v1 in `maven.yml`.
- Restores the Build & Test workflow to its last known-good state (commit `492d456`).

## Why

The two action major bumps (#85, #90) broke Build & Test on master — every run since `630dbff` is `startup_failure`, last green was `492d456`. `setup-java@v5` also requires a `distribution` input the workflow doesn't provide. Major action bumps are now excluded by `dependabot.yml` (#97), so these won't be re-proposed automatically.

## Test plan
- [x] `maven.yml` is byte-identical to the last green commit's version
- [ ] Build & Test goes green on this PR