### PR TITLE
chore(release): bump version to 1.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>1.11.0</version>
+  <version>1.12.0</version>
 
   <packaging>jar</packaging>
 


### PR DESCRIPTION
## Summary

Bump `pom.xml` version `1.11.0` → `1.12.0` to release the changes merged since v1.11.0.

The published artifact has real changes since the last release:
- **feat(investment):** new `Investment` fields `issueDate`, `purchaseDate`, `issuerCNPJ` (#82)
- **feat(version):** `User-Agent` now includes the Java version suffix (#95)

`feat:` changes since the last tag → minor bump.

## Release mechanics

Merging to `master` triggers `release.yml` (tags `v1.12.0`, cuts the GitHub Release), which triggers `maven-publish.yml` to build → test → deploy to GitHub Packages. Without this bump nothing publishes, so these changes are currently unreleased.

## Test plan
- [x] `pom.xml` is valid (`mvn validate`)