### PR TITLE
fix(ci): revert action bumps in maven-publish workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -22,7 +22,7 @@ jobs:
           ref: ${{ github.event.release.tag_name || github.event.inputs.tag_version || 'master' }}
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v1
         with:
           java-version: 1.8
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
@@ -40,7 +40,7 @@ jobs:
           ref: ${{ github.event.release.tag_name || github.event.inputs.tag_version || 'master' }}
 
       - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@v4
+        uses: dopplerhq/cli-action@v1
 
       - name: Login in Doppler
         run: doppler setup --token=${{ secrets.DOPPLER_TOKEN_PROD }} --no-prompt
@@ -80,7 +80,7 @@ jobs:
           ref: ${{ github.event.release.tag_name || github.event.inputs.tag_version || 'master' }}
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v1
         with:
           java-version: 1.8
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml


### PR DESCRIPTION
## Summary

Revert `actions/setup-java` v5 → v1 and `dopplerhq/cli-action` v4 → v1 in `maven-publish.yml`, matching the last known-good publish (v1.11.0).

## Why

#103 fixed the same major action bumps in `maven.yml` but missed `maven-publish.yml`, which the bumps (#85, #90) also touched. `dopplerhq/cli-action@v4` isn't on the repo's allowed-actions list (only `@v1`), so the publish workflow fails at startup — that's why **v1.12.0 was tagged/released but never deployed to GitHub Packages**.

## Next step after merge

Re-dispatch the publish: `gh workflow run maven-publish.yml -f tag_version=v1.12.0` (workflow_dispatch uses the workflow definition from `master`, so this fix must land first).

## Test plan
- [x] `maven-publish.yml` is byte-identical to the last green publish (v1.11.0)