### PR TITLE
fix(account): rename ReservedBalance.amounts to availableAmounts

### DIFF
--- a/src/main/java/ai/pluggy/client/response/ReservedBalance.java
+++ b/src/main/java/ai/pluggy/client/response/ReservedBalance.java
@@ -11,5 +11,5 @@ public class ReservedBalance {
 
   String name;
   String identification;
-  List<ReservedBalanceAmount> amounts;
+  List<ReservedBalanceAmount> availableAmounts;
 }


### PR DESCRIPTION
## Summary

- The API returns `availableAmounts` for each entry in `bankData.reservedBalances` — see the `ReservedBalance` schema in https://api.pluggy.ai/oas3.json, where it is a required property. The field was declared as `amounts`.
- Gson maps by field name, so it always deserialized to `null` and reserved balances ("caixinhas") came back empty.
- Shipped this way since v1.10.0, so the field has never worked.

Breaking rename at the API-surface level, but no working caller can depend on `amounts` — it was never populated.

The same field name is wrong in `pluggy-node` and `pluggy-net`; fixes for those are opened separately.

## Test plan

- [ ] CI build — I could not compile locally: `mvn compile` fails on `master` with or without this change (~200 errors), because Lombok 1.18.32 does not support JDK 21 and annotation processing is skipped. Unrelated to this change, and addressed by the pending Lombok bump in #102.
- [x] Change is a single field rename with no other references to it in the repo.