### PR TITLE
chore(release): bump version to 1.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>ai.pluggy</groupId>
   <artifactId>pluggy-java</artifactId>
-  <version>1.12.0</version>
+  <version>1.13.0</version>
 
   <packaging>jar</packaging>
 


### PR DESCRIPTION
## Summary

Release the changes merged since `v1.12.0`:

- `fix(account)`: rename `ReservedBalance.amounts` to `availableAmounts` (#108)
- `feat(cc)`: adding cc bill dates (#107)

Minor rather than patch because of the feat in #107.

`v1.12.0` was already tagged, so the last two merges did not cut a release — `release.yml` logged `Tag v1.12.0 already exists, skipping release`. This bump is what lets it tag again.

## After merge

Merging triggers `release.yml`, which tags `v1.13.0` and cuts the GitHub Release. Publishing the jar to GitHub Packages is a separate manual step (#106), since the Release is created with the default `GITHUB_TOKEN` and GitHub does not fire workflow triggers for those events:

```
gh workflow run maven-publish.yml -f tag_version=v1.13.0
```

Until that dispatch runs, `availableAmounts` is not available to consumers of this SDK.

## Test plan

- [x] Single-line version bump; `pom.xml` had exactly one `<version>1.12.0</version>` occurrence.
- [ ] CI build & test on this PR
- [ ] After merge: `gh release view v1.13.0`, then the manual `maven-publish.yml` dispatch and its deploy job